### PR TITLE
Fix/64 bits processor compatibility

### DIFF
--- a/conv_net_classes.py
+++ b/conv_net_classes.py
@@ -328,7 +328,7 @@ class LogisticRegression(object):
         # check if y has same dimension of y_pred
         if y.ndim != self.y_pred.ndim:
             raise TypeError('y should have the same shape as self.y_pred',
-                ('y', target.type, 'y_pred', self.y_pred.type))
+                ('y', y.type, 'y_pred', self.y_pred.type))
         # check if y is of the correct datatype
         if y.dtype.startswith('int'):
             # the T.neq operator returns a vector of 0s and 1s, where 1

--- a/conv_net_sentence.py
+++ b/conv_net_sentence.py
@@ -75,7 +75,7 @@ def train_conv_net(datasets,
     index = T.lscalar()
     x = T.matrix('x')   
     y = T.ivector('y')
-    Words = theano.shared(value = U, name = "Words")
+    Words = theano.shared(value = np.asarray(U, dtype=theano.config.floatX), name = "Words")
     zero_vec_tensor = T.vector()
     zero_vec = np.zeros(img_w)
     set_zero = theano.function([zero_vec_tensor], updates=[(Words, T.set_subtensor(Words[0,:], zero_vec_tensor))], allow_input_downcast=True)


### PR DESCRIPTION
The code raises "NotImplementedError: The image and the kernel must have the same type.inputs(float32), kerns(float64)" when it is run on 64 bits machine.
This bug is fixed by casting Words tensor to theano.config.floatX
