### PR TITLE
fix choosing the activation func

### DIFF
--- a/conv_net_classes.py
+++ b/conv_net_classes.py
@@ -408,7 +408,7 @@ class LeNetConvPoolLayer(object):
         if self.non_linear=="tanh":
             conv_out_tanh = T.tanh(conv_out + self.b.dimshuffle('x', 0, 'x', 'x'))
             output = downsample.max_pool_2d(input=conv_out_tanh, ds=self.poolsize, ignore_border=True)
-        if self.non_linear=="relu":
+        elif self.non_linear=="relu":
             conv_out_tanh = ReLU(conv_out + self.b.dimshuffle('x', 0, 'x', 'x'))
             output = downsample.max_pool_2d(input=conv_out_tanh, ds=self.poolsize, ignore_border=True)
         else:


### PR DESCRIPTION
In predict(), output obtained with tanh can never be returned due to an error in the conditional statement. This fix makes it possible to choose any of tanh, relu or other.